### PR TITLE
Corrected node module file names in demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -69,8 +69,8 @@
 <script src="/node_modules/angular/angular.js"></script>
 
 <!-- AngularJS Modules -->
-<script src="/node_modules/angular-ui-bootstrap/dist/ui-bootstrap.js"></script>
-<script src="/node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js"></script>
+<script src="/node_modules/angular-ui-bootstrap/dist/ui-bootstrap-1.2.3.js"></script>
+<script src="/node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls-1.2.3.js"></script>
 <script src="/node_modules/angular-ui-router/release/angular-ui-router.js"></script>
 
 <!-- ui-navbar script -->


### PR DESCRIPTION
Maybe it was intentional to leave off the node module version numbers. If that's the case and you don't want to merge with this pull request, consider making it more obvious that you need to add the version numbers when you clone it.
